### PR TITLE
fix: ensure ecmaversion and env globals match

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
 
   "parserOptions": {
-    "ecmaVersion": "latest",
+    "ecmaVersion": 2020,
     "sourceType": "module",
     "ecmaFeatures": {}
   },


### PR DESCRIPTION
ensure ecmaversion and registered globals match: 

current configuration setting ecmaversion to 2023 by using "latest", while only registering globals for 2020. This change puts them at the same target.

```
  "parserOptions": {
    "ecmaVersion": 2020,
```

```
  "env": {
    "es2020": true,
```

See: https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options

Fixes tool configuration. 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).